### PR TITLE
clarify frontend container networking and API port usage

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,6 +4,10 @@ import GoalInput from "./components/goals/GoalInput";
 import CourseGoals from "./components/goals/CourseGoals";
 import ErrorAlert from "./components/UI/ErrorAlert";
 
+//1: The backend is running on port 8070.
+
+//2: By default, the browser assumes port 80 for HTTP requests (or 443 for HTTPS).
+
 function App() {
   const [loadedGoals, setLoadedGoals] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -14,7 +18,17 @@ function App() {
       setIsLoading(true);
 
       try {
-        const response = await fetch("http://goals-backend/goals");
+        /**
+         * 
+         * Common Error: net::ERR_NAME_NOT_RESOLVED
+         * In the frontend code, we reference goals-backend (the backend container name) as the API host. However, this does not work in the browser, because the browser runs outside the Docker network and has no knowledge of container names like goals-backend.
+
+         *  In the frontend container, the only process running is the development server that serves the React application. When you access the app via localhost:3000 in your browser, any API call made to http://goals-backend:8070 fails because the browser tries to resolve goals-backend as a public DNS name, which doesn’t exist — hence the error:
+
+         * Failed to load resource: net::ERR_NAME_NOT_RESOLVED
+         */
+
+        const response = await fetch("http://localhost:8070/goals");
 
         const resData = await response.json();
 
@@ -39,7 +53,7 @@ function App() {
     setIsLoading(true);
 
     try {
-      const response = await fetch("http://goals-backend/goals", {
+      const response = await fetch("http://localhost:8070/goals", {
         method: "POST",
         body: JSON.stringify({
           text: goalText,
@@ -78,7 +92,7 @@ function App() {
     setIsLoading(true);
 
     try {
-      const response = await fetch("http://goals-backend/goals/" + goalId, {
+      const response = await fetch("http://localhost:8070/goals/" + goalId, {
         method: "DELETE",
       });
 


### PR DESCRIPTION
- Removed custom network from frontend container as it's not needed
- Explained why API calls must include backend port (e.g., :8070) in fetch URLs