### PR TITLE
add nodemon troubleshooting and bind mount instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,52 @@ We use nodemon to automatically restart the Node.js server whenever file changes
 }
 
 nodemon watches the files and reloads the server, making local development faster and smoother.
+
+-- Notes for Development with Docker and Nodemon
+
+-- Using nodemon with Docker for Hot Reloading
+
+During development, we use nodemon to automatically restart the backend server when code changes are made. However, when running inside a Docker container on Windows (especially with WSL2), nodemon sometimes fails to detect file changes from the bind mount.
+
+Issue Encountered:
+
+Even though app.js was updated in the local system and the container had the updated file (verified using cat), nodemon still ran the old version of the app. This happened because:
+
+A: nodemon didn’t detect the file change at startup.
+
+B: The Docker bind mount was working, but the watcher missed the event.
+
+Solution:
+Create a nodemon.json file in the backend project directory with the following content:
+
+{
+"watch": ["."],
+"ext": "js,json",
+"delay": "500",
+"legacyWatch": true,
+"ignore": ["node_modules"]
+}
+
+This ensures that nodemon:
+
+A: Uses legacy watch mode (required for file watching in Docker on Windows).
+
+B: Ignores noisy folders like node_modules.
+
+C: Watches all .js and .json files in the app folder.
+
+-- Backend Container Run Command (with Volume Bind Mount)
+
+Use the following command to run the backend container with logs and source code mounted:
+
+docker run --name goals-backend \
+ --rm -d \
+ -p 8070:8070 \
+ --network goals-network \
+ -v logs:/app/logs \
+ -v "/absolute/path/to/your/local/backend:/app" \
+ -v /app/node_modules \
+ goals-node
+
+Replace:
+/absolute/path/to/your/local/backend with your actual project path on your system (e.g., /run/desktop/mnt/host/c/Users/your-name/project/backend on Windows+WSL).

--- a/backend/nodemon.json
+++ b/backend/nodemon.json
@@ -1,0 +1,7 @@
+{
+  "watch": ["."],
+  "ext": "js,json",
+  "delay": "500",
+  "legacyWatch": true,
+  "ignore": ["node_modules"]
+}


### PR DESCRIPTION
- Explained issue with nodemon not detecting file changes in Docker on Windows
- Added solution using nodemon.json with legacyWatch enabled
- Updated backend container run command with bind mount (generic path)
- Removed machine-specific file paths from README