### PR TITLE
feat: add PowerShell run scripts for dev and prod modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,3 +470,26 @@ How We Fixed It
 
 3: We rebuilt fresh: Now MongoDB creates the correct root user, and authentication succeeds.
 Backend and seed containers now connect successfully.
+
+#### Run Scripts for Development & Production
+
+This project includes two PowerShell scripts for convenience:
+
+Script Purpose
+run-dev.ps1 Run in development mode (hot reload, port 3001)
+run-prod.ps1 Run in production mode (frontend via nginx, port 3000 → 80)
+
+Usage:
+
+# For development mode (Vite dev server on port 3001)
+
+.\run-dev.ps1
+
+# For production mode (nginx reverse-proxy to frontend on port 3000)
+
+.\run-prod.ps1
+
+Notes:
+These scripts are not copied into Docker images (.dockerignore) because they are only used locally for running docker-compose.
+
+The scripts are versioned in git because they are helpful for any developer working on this project.

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -24,3 +24,6 @@ docker-compose*.yml
 # OS metadata
 .DS_Store
 Thumbs.db
+
+../run-dev.ps1
+../run-prod.ps1

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -34,3 +34,6 @@ docker-compose\*.yaml
 
 .DS_Store
 Thumbs.db
+
+../run-dev.ps1
+../run-prod.ps1

--- a/run-dev.ps1
+++ b/run-dev.ps1
@@ -1,0 +1,6 @@
+# run-dev.ps1
+Write-Host "Running Dev Mode on port 3001 ..."
+docker-compose down
+$env:BUILD_TARGET = "dev"
+$env:DEV_PORT = "3001"
+docker-compose -f docker-compose.yaml -f docker-compose.override.yaml up --build

--- a/run-prod.ps1
+++ b/run-prod.ps1
@@ -1,0 +1,5 @@
+# run-prod.ps1
+Write-Host "Running Prod Mode (nginx on port 3000 -> 80) ..."
+docker-compose -f docker-compose.yaml down
+$env:BUILD_TARGET = "frontend-react"
+docker-compose -f docker-compose.yaml up --build


### PR DESCRIPTION
- Added run-dev.ps1 for running development mode on port 3001
- Added run-prod.ps1 for running production mode (nginx on port 3000 → 80)
- Scripts excluded from Docker image (via .dockerignore), but included in git for developer use
- Updated README with usage instructions