### PR TITLE
fix: ensure Jenkins pipeline correctly builds and locates /frontend context

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,13 +16,19 @@ pipeline {
 
     stage('Build & Run Containers') {
       steps {
-        sh "${COMPOSE_CMD} up -d --build"
+        dir("${env.WORKSPACE}") {
+          sh "pwd && ls -la"
+          sh "${COMPOSE_CMD} up -d --build"
+        }
       }
     }
 
     stage('Verify Running Containers') {
       steps {
-        sh "docker ps"
+        dir("${env.WORKSPACE}") {
+          sh "docker ps"
+        }
+        
       }
     }
   }


### PR DESCRIPTION
- Added dir(env.WORKSPACE) block in Jenkinsfile to ensure pipeline runs in correct project root
- Verified frontend folder exists and is correctly passed as Docker build context
- Resolved "unable to prepare context: path '/frontend' not found" error
- Ensured multi-container build (frontend/backend/ mongodb) now completes successfully