### PR TITLE
fix(jenkins): debug missing /frontend context during docker-compose

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,8 @@ pipeline {
       steps {
         dir("${env.WORKSPACE}") {
           sh "pwd && ls -la"
+          sh "ls -la ./frontend"
+          sh "ls -la ./backend"
           sh "${COMPOSE_CMD} up -d --build"
         }
       }


### PR DESCRIPTION
- Added listing of ./frontend directory in Jenkins pipeline
- Helps verify context visibility before docker-compose build
- Attempting to resolve "unable to prepare context : path '/frontend' not found" error