### PR TITLE
fix(frontend): corrected absolute context path in

### DIFF
--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   frontend:
     build:
-      context: /frontend
+      context: ./frontend
       dockerfile: Dockerfile
       target: ${BUILD_TARGET:-dev}
     ports:


### PR DESCRIPTION
docker-compose.override.yaml
The frontend service in `docker-compose.override
.yaml` had an incorrect absolute context path
`/frontend`, which caused Docker to fail with
"unable to prepare context: path '/frontend' not
found" in Jenkins CI.

Replaced it with the correct relative path
`./frontend`, aligning with
the project structure and the base
`docker-compose.yaml`.

This fix ensures that the build context resolves
correctly across all
environments, including local dev and CI/CD
pipelines.