### PR TITLE
fix(ci): move dev container run logic to shell script in Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,9 +3,6 @@ pipeline {
     label 'myagents'  // Make sure this matches your agent label in Jenkins
   }
 
-  environment {
-    COMPOSE_CMD = "docker-compose -f docker-compose.yaml -f docker-compose.override.yaml"
-  }
 
   stages {
     stage('Checkout') {
@@ -17,10 +14,8 @@ pipeline {
     stage('Build & Run Containers') {
       steps {
         dir("${env.WORKSPACE}") {
-          sh "pwd && ls -la"
-          sh "ls -la ./frontend"
-          sh "ls -la ./backend"
-          sh "${COMPOSE_CMD} up -d --build"
+         sh 'chmod +x run-dev.sh'
+         sh './run-dev.sh'
         }
       }
     }

--- a/run-dev.sh
+++ b/run-dev.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo "Running Dev Mode on port 3001 ..."
+docker-compose down
+export BUILD_TARGET=dev
+export DEV_PORT=3001
+docker-compose -f docker-compose.yaml -f docker-compose.override.yaml up --build

--- a/run-prod.sh
+++ b/run-prod.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+echo "Running Prod Mode (nginx on port 3000 → 80) ..."
+
+# Stop and remove existing containers
+docker-compose -f docker-compose.yaml down
+
+# Set environment variable for production target
+export BUILD_TARGET=frontend-react
+
+# Start and build containers using just the main compose file
+docker-compose -f docker-compose.yaml up --build


### PR DESCRIPTION
- Previously, the Jenkinsfile had hardcoded `docker-compose` commands with static environment
values, making it hard to switch between dev and
prod setups and reuse logic.

- This commit extracts the dev mode startup logic into a standalone shell script
(`run-dev.sh` / `run-dev.ps1`) and uses it in the
Jenkins pipeline. This improves maintainability,
environment flexibility, and local dev alignment.

- Also sets dynamic BUILD_TARGET and DEV_PORT via environment variables before compose up.

- Related Issue: Port conflict due to hardcoded static port mapping in override file.