### PR TITLE
 added run-prod.sh for CI-safe production build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,8 +23,8 @@ pipeline {
     stage('Build & Run Containers') {
       steps {
         dir("${env.WORKSPACE}") {
-         sh 'chmod +x run-dev.sh'
-         sh './run-dev.sh'
+         sh 'chmod +x run-prod.sh'
+         sh './run-prod.sh'
         }
       }
     }


### PR DESCRIPTION
- run-prod.sh avoids local development volumes and sets port to 3000
- prevents container src overwrite in CI caused by override mounts