### PR TITLE
fix: use secure syntax for email credentials in Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ pipeline {
   post {
     failure {
       echo 'Pipeline failed! Sending alert...'
-      mail to: "${env.NOTIFY_EMAILS}",
+      mail to: env.NOTIFY_EMAILS,
            subject: "Build Failed: ${env.JOB_NAME} [#${env.BUILD_NUMBER}]",
            body: "View details here: ${env.BUILD_URL}"
     }

--- a/README.md
+++ b/README.md
@@ -668,3 +668,37 @@ sh 'cat frontend/src/index.js'
 to
 
 sh 'cat frontend/src/this_file_does_not_exist.js'
+
+### Email Notification Setup
+
+To enable failure alert emails:
+
+1: Create a Jenkins Secret Text credential with:
+
+ID: notify-emails
+
+Secret: your email address (e.g., your.email@example.com)
+
+2: Configure SMTP in Jenkins:
+
+-> Go to Manage Jenkins → Configure System
+
+-> Under Extended E-mail Notification, add your SMTP settings
+
+3: Your Jenkinsfile should use the credential securely:
+
+environment {
+  NOTIFY_EMAILS = credentials('notify-emails')
+}
+
+post {
+  failure {
+    echo 'Pipeline failed! Sending alert...'
+    mail to: env.NOTIFY_EMAILS, // ✅ Secure way — no Groovy interpolation
+         subject: "Build Failed: ${env.JOB_NAME} [#${env.BUILD_NUMBER}]",
+         body: "View details here: ${env.BUILD_URL}"
+  }
+}
+
+
+Security Tip: Avoid "${env.SECRET}" when referencing credentials. Use env.SECRET directly to prevent leakage in logs or stack traces.


### PR DESCRIPTION
-  Replaced insecure Groovy string interpolation ( "${env.NOTIFY_EMAILS}") with direct variable reference (env.NOTIFY_EMAILS)
- Eliminated Jenkins warning about passing secrets insecurely to the mail step
- Ensures better protection of sensitive values in logs and error traces