### PR TITLE
feat: Add Jenkins parameter support for dynamic Docker image tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,4 +702,27 @@ body: "View details here: ${env.BUILD_URL}"
 
 Security Tip: Avoid "${env.SECRET}" when referencing credentials. Use env.SECRET directly to prevent leakage in logs or stack traces.
 
-### Removable Comments
+## Jenkins Pipeline Parameters
+
+This project supports dynamic Docker image tagging using Jenkins parameters.
+
+### `IMAGE_TAG` Parameter
+
+The Jenkins pipeline accepts a string parameter named `IMAGE_TAG` (default: `latest`). This value is passed into the pipeline and used to:
+
+- Tag backend and frontend Docker images (e.g., `goals-backend:build-43`)
+- Control behavior in the `prod-run.sh` deployment script
+- Enable consistent tagging for image versioning and traceability
+
+### Example Jenkins Usage
+
+When running the pipeline:
+
+- If prompted for `IMAGE_TAG`, enter a value like `v1.0.0` or `build-42`
+- If left blank, it will default to `latest`
+
+### Affected Files
+
+- `Jenkinsfile`: Defines `parameters { string(name: 'IMAGE_TAG' ...) }`
+- `prod-run.sh`: Uses `${IMAGE_TAG}` with fallback and passes it to Docker Compose
+- `docker-compose.yaml`: Tags `backend` and `frontend` images using `${IMAGE_TAG}`

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,10 +11,12 @@ services:
       MONGO_INITDB_DATABASE: ${MONGO_INITDB_DATABASE}
   backend:
     container_name: goals-backend
-    # build: ./backend
     build:
       context: ./backend
       dockerfile: Dockerfile
+      args:
+        IMAGE_TAG: ${IMAGE_TAG}
+    image: goals-backend:${IMAGE_TAG}
     ports:
       - 8070:8070
     volumes:
@@ -30,6 +32,9 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
+      args:
+        IMAGE_TAG: ${IMAGE_TAG}
+    image: goals-frontend:${IMAGE_TAG}
     ports:
       - 3000:80
     depends_on:

--- a/run-prod.sh
+++ b/run-prod.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
+set -e
+
 echo "Running Prod Mode (nginx on port 3000 → 80) ..."
+
+# Use provided IMAGE_TAG or default to 'latest'
+TAG=${IMAGE_TAG:-latest}
+echo "Using Docker image tag: $TAG"
 
 # Stop and remove existing containers
 docker-compose -f docker-compose.yaml down
@@ -8,5 +14,8 @@ docker-compose -f docker-compose.yaml down
 # Set environment variable for production target
 export BUILD_TARGET=frontend-react
 
-# Start and build containers using just the main compose file
+# Export TAG so it can be used in docker-compose as build-arg
+export IMAGE_TAG=$TAG
+
+# Start and build containers
 docker-compose -f docker-compose.yaml up -d --build


### PR DESCRIPTION
- Introduced IMAGE_TAG parameter in Jenkinsfile (default: 'latest')

- Updated prod-run.sh to consume IMAGE_TAG and export it

- Modified docker-compose.yaml to use IMAGE_TAG for backend/frontend image tagging

- Enables traceable and versioned image builds for CI/CD pipelines